### PR TITLE
all four quadrants displayed with styles

### DIFF
--- a/src/javascripts/components/eatQuadrant.js
+++ b/src/javascripts/components/eatQuadrant.js
@@ -19,11 +19,15 @@ const unhealthyButtonClicked = () => {
 const eatButtonEvents = () => {
   $('#btn-healthy').click(() => {
     $('#fullnessScore').html('');
-    $('#fullnessScore').html(`Fullness Score: ${healthyButtonClicked()}`);
+    $('#fullnessScore').html(`
+    <div class="score">Fullness Score: ${healthyButtonClicked()}</div>
+    <progress id="eat-progress" class="progress" value="${fullnessScore}" max="100"></progress>`);
   });
   $('#btn-unhealthy').click(() => {
     $('#fullnessScore').html('');
-    $('#fullnessScore').html(`Fullness Score: ${unhealthyButtonClicked()}`);
+    $('#fullnessScore').html(`
+    <div class="score">Fullness Score: ${unhealthyButtonClicked()}</div>
+    <progress id="eat-progress" class="progress" value="${fullnessScore}" max="100"></progress>`);
   });
 };
 
@@ -35,7 +39,10 @@ const displayEatQuadrant = () => {
         <button id="btn-healthy">Eat Healthy Food</button>
         <button id="btn-unhealthy">Eat Unhealthy Food</button>
       </div>
-      <div id="fullnessScore">Fullness Score: ${fullnessScore}</div>
+      <div id="fullnessScore">
+        <div class="score">Fullness Score: ${fullnessScore}</div>
+        <progress id="eat-progress" class="progress" value="${fullnessScore}" max="100"></progress>
+      </div>
     </div>
   `;
   $('#eat').html(domString);

--- a/src/javascripts/components/fightQuadrant.js
+++ b/src/javascripts/components/fightQuadrant.js
@@ -19,11 +19,15 @@ const commitViolenceButtonClicked = () => {
 const fightButtonEvents = () => {
   $('#btn-run-away').click(() => {
     $('#strengthScore').html('');
-    $('#strengthScore').html(`Strength Score: ${runAwayButtonClicked()}`);
+    $('#strengthScore').html(`
+    <div class="score">Strength Score: ${runAwayButtonClicked()}</div>
+    <progress id="fight-progress" class="progress" value="${strengthScore}" max="100"></progress>`);
   });
   $('#btn-commit-violence').click(() => {
     $('#strengthScore').html('');
-    $('#strengthScore').html(`Strength Score: ${commitViolenceButtonClicked()}`);
+    $('#strengthScore').html(`
+    <div class="score">Strength Score: ${commitViolenceButtonClicked()}</div>
+    <progress id="fight-progress" class="progress" value="${strengthScore}" max="100"></progress>`);
   });
 };
 
@@ -35,7 +39,10 @@ const displayFightQuadrant = () => {
         <button id="btn-run-away">Run Away</button>
         <button id="btn-commit-violence">Commit Violence</button>
       </div>
-      <div id="strengthScore">Strength Score: ${strengthScore}</div>
+      <div id="strengthScore">
+        <div class="score">Strength Score: ${strengthScore}</div>
+        <progress id="fight-progress" class="progress" value="${strengthScore}" max="100"></progress>
+      </div>
     </div>
   `;
   $('#fight').html(domString);

--- a/src/javascripts/components/playQuadrant.js
+++ b/src/javascripts/components/playQuadrant.js
@@ -19,11 +19,14 @@ const slightlyFunButtonClicked = () => {
 const playButtonEvents = () => {
   $('#btn-super-fun').click(() => {
     $('#funScore').html('');
-    $('#funScore').html(`Fun Score: ${superFunButtonClicked()}`);
+    $('#funScore').html(`
+    <div class="score">Fun Score: ${superFunButtonClicked()}</div>
+    <progress id="play-progress" class="progress" value="${funScore}" max="100"></progress>`);
   });
   $('#btn-slightly-fun').click(() => {
     $('#funScore').html('');
-    $('#funScore').html(`Fun Score: ${slightlyFunButtonClicked()}`);
+    $('#funScore').html(`<div class="score">Fun Score: ${slightlyFunButtonClicked()}</div>
+    <progress id="play-progress" class="progress" value="${funScore}" max="100"></progress>`);
   });
 };
 
@@ -35,7 +38,10 @@ const displayPlayQuadrant = () => {
         <button id="btn-super-fun">Super Fun Activity</button>
         <button id="btn-slightly-fun">Slightly Fun Activity</button>
       </div>
-      <div id="funScore">Fun Score: ${funScore}</div>
+      <div id="funScore">
+        <div class="score">Fun Score: ${funScore}</div>
+        <progress id="play-progress" class="progress" value="${funScore}" max="100"></progress>
+      </div>
     </div>
   `;
   $('#play').html(domString);

--- a/src/javascripts/components/sleepQuadrant.js
+++ b/src/javascripts/components/sleepQuadrant.js
@@ -19,11 +19,15 @@ const deepSleepButtonClicked = () => {
 const sleepButtonEvents = () => {
   $('#btn-take-nap').click(() => {
     $('#energyScore').html('');
-    $('#energyScore').html(`Energy Score: ${takeNapButtonClicked()}`);
+    $('#energyScore').html(`
+    <div class="score">Energy Score: ${takeNapButtonClicked()}</div>
+    <progress id="sleep-progress" class="progress" value="${energyScore}" max="100"></progress>`);
   });
   $('#btn-deep-sleep').click(() => {
     $('#energyScore').html('');
-    $('#energyScore').html(`Energy Score: ${deepSleepButtonClicked()}`);
+    $('#energyScore').html(`
+    <div class="score">Energy Score: ${deepSleepButtonClicked()}</div>
+    <progress id="sleep-progress" class="progress" value="${energyScore}" max="100"></progress>`);
   });
 };
 
@@ -35,7 +39,10 @@ const displaySleepQuadrant = () => {
         <button id="btn-take-nap">Take a Nap</button>
         <button id="btn-deep-sleep">Deep Sleep</button>
       </div>
-      <div id="energyScore">Energy Score: ${energyScore}</div>
+      <div id="energyScore">
+        <div class="score">Energy Score: ${energyScore}</div>
+        <progress id="sleep-progress" class="progress" value="${energyScore}" max="100"></progress>
+      </div>
     </div>
   `;
   $('#sleep').html(domString);

--- a/src/styles/components/_app.scss
+++ b/src/styles/components/_app.scss
@@ -1,0 +1,6 @@
+#app {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    height: 100%;
+}

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -1,0 +1,12 @@
+button {
+    background-color: #FFC15E;
+    border-radius: 10px;
+    border: none;
+    color: #48284A;
+    margin: 5px;
+    padding: 4px 8px;
+}
+
+button:hover {
+    background-color: #FFC870;
+}

--- a/src/styles/components/_progress.scss
+++ b/src/styles/components/_progress.scss
@@ -1,0 +1,14 @@
+progress {
+    border-radius: 7px; 
+    height: 22px;
+    width: 100%;
+  }
+
+  progress::-webkit-progress-bar {
+    background-color: white;
+    border-radius: 7px;
+  }
+
+  progress::-webkit-progress-value {
+    background-color: #FFC870;
+  }

--- a/src/styles/components/_quad.scss
+++ b/src/styles/components/_quad.scss
@@ -1,0 +1,5 @@
+.quad {
+    display: flex;
+    flex-direction: column;
+    flex-basis: 50%;
+}

--- a/src/styles/components/_quadrants.scss
+++ b/src/styles/components/_quadrants.scss
@@ -1,0 +1,17 @@
+%quadrant {
+    margin: 10px;
+    border-radius: 25px;
+    color: white;
+    padding: 20px;
+    text-align: center;
+}
+
+@each $div, $div-color in $quadrant-list {
+    .#{$div}-div {
+        @extend %quadrant;
+        background-color: #{$div-color};
+    }
+    .score {
+        padding: 10px;
+    }
+}

--- a/src/styles/components/index.scss
+++ b/src/styles/components/index.scss
@@ -1,0 +1,5 @@
+@import './buttons';
+@import './quadrants';
+@import './quad';
+@import './app';
+@import './progress';

--- a/src/styles/globals/_lists.scss
+++ b/src/styles/globals/_lists.scss
@@ -1,0 +1,8 @@
+@import './variables';
+
+$quadrant-list: (
+    (eat, $eat),
+    (play, $play),
+    (fight, $fight),
+    (sleep, $sleep)
+)

--- a/src/styles/globals/_variables.scss
+++ b/src/styles/globals/_variables.scss
@@ -1,0 +1,4 @@
+$eat: #00635D;
+$play: #D68589;
+$fight: #48284A;
+$sleep: #73A2AB;

--- a/src/styles/globals/index.scss
+++ b/src/styles/globals/index.scss
@@ -1,0 +1,2 @@
+@import './lists';
+@import './variables';

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,9 +1,8 @@
 @import "~bootstrap/scss/bootstrap";
 @import "~@fortawesome/fontawesome-free/css/all.min.css";
 
-body {
-  background-color: antiquewhite;
-  color: brown;
-  text-align: center;
-  margin-top: 100px;
-}
+//GLOBALS
+@import './globals/';
+
+//COMPONENTS
+@import './components/';


### PR DESCRIPTION
## Description
Updated page with different colors for each quadrant and progress bars

## Related Issue
Resolves #10 

## Motivation and Context
The page is much more visually appealing now, drawing the user in to continue playing with the app longer.

## How Can This Be Tested?
```git fetch origin styles```

## Screenshots (if appropriate):
<img width="934" alt="Screen Shot 2020-09-07 at 7 44 22 PM" src="https://user-images.githubusercontent.com/63985074/92422327-8b92a300-f142-11ea-8b45-924aee8e6832.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
